### PR TITLE
Updates to dupcman.f and duptac.f to test for 0 reports in input file.

### DIFF
--- a/sorc/bufr_dupcman.fd/dupcman.f
+++ b/sorc/bufr_dupcman.fd/dupcman.f
@@ -24,6 +24,9 @@ c     DUPLICATIONS FOR C-MAN TAC FORMAT 001.004 AND C-MAN BUFR FORMAT
 C     001.104. 
 C 2021-08-28  D. STOKES -- MODIFIED IMST DATA STATEMENT TO INITIALIZE
 C     ALL 113 ARRAY ELEMENTS
+C 2022-03-22  I. GENKOVA -- ADDED CHECK FOR 0 REPORTS IN INPUT FILE AND
+C     ALLOWS FOR GRACEFUL CONTINUE IN THE EVENT OF 0 REPORTS.
+C     CORRECTLY INITIALIZED IMST.
 C
 C USAGE:
 C   INPUT FILES:
@@ -98,10 +101,10 @@ C$$$
       DATA IMST  /  3*-99, 1, 99*-99, 2, 9*-99 /
 C-----------------------------------------------------------------------
 C-----------------------------------------------------------------------
-      CALL W3TAGB('BUFR_DUPCMAN',2021,0241,2250,'NP22')
+      CALL W3TAGB('BUFR_DUPCMAN',2022,0081,2250,'NP22')
 
       print *
-      print * ,'---> Welcome to BUFR_DUPCMAN - Version 08-28-2021'
+      print * ,'---> Welcome to BUFR_DUPCMAN - Version 03-22-2022'
       print *
 
       CALL DATELEN(10)
@@ -177,6 +180,13 @@ C  ---------------------------------------------------------------
 
          MXTB = MXTB + NUM_SUBSETS
       ENDDO
+
+      IF(MXTB.EQ.0) THEN
+         PRINT *
+         PRINT *, '### WARNING: A total of ZERO input cman reports'
+         PRINT *
+         GO TO 400
+      ENDIF
 
       ALLOCATE(TAB_8(MXTS,MXTB),STAT=I);IF(I.NE.0) GOTO 901
       ALLOCATE(RAB_8(MXTS,MXTB),STAT=I);IF(I.NE.0) GOTO 901
@@ -485,6 +495,8 @@ C  -------------------------------------------------------------------
             CLOSE(LUBFI)
          ENDIF
       ENDDO
+
+ 400  CONTINUE
  
 C  GENERATE REPORT
 C  ---------------

--- a/sorc/bufr_duptac.fd/duptac.f
+++ b/sorc/bufr_duptac.fd/duptac.f
@@ -23,8 +23,10 @@ C 2020-08-20  J. Whiting   Original version for implementation
 c     New code to check for and remove duplicate reports found in TAC
 C     feed data streams relative to the BUFR feed replacements.
 C     Currently configured for buoy (moored & drifting) data streams
-c     (TAC: mbuoy/nc001003 dbuoy/nc001002, and 
-c     BUFR: mbuoyb/nc001103 dbuoyb/nc001102).
+C     (TAC: mbuoy/nc001003 dbuoy/nc001002, and 
+C     BUFR: mbuoyb/nc001103 dbuoyb/nc001102).
+C 2022-03-22  I. Genkova   Added check for 0 reports in input file
+C     and allows for graceful continue in the event of 0 reports.
 C
 C USAGE:
 C   INPUT FILES:
@@ -99,10 +101,10 @@ C$$$
 
 C-----------------------------------------------------------------------
 C-----------------------------------------------------------------------
-      CALL W3TAGB('BUFR_DUPTAC',2020,0233,0050,'EMC')
+      CALL W3TAGB('BUFR_DUPTAC',2022,0081,0050,'EMC')
 
 
-      print * ,'---> Welcome to BUFR_DUPTAC - v08-20-2020'
+      print * ,'---> Welcome to BUFR_DUPTAC - v03-22-2022'
       call bvers(cvstr)
       print'(13x,"(BUFRLIB version = v",a,")",//)', trim(cvstr)
 
@@ -215,6 +217,13 @@ C  ---------------------------------------------------------------
 
          MXTB = MXTB + NUM_SUBSETS
       ENDDO
+
+      IF(MXTB.EQ.0) THEN
+         PRINT *
+         PRINT *, '### WARNING: A total of ZERO input reports'
+         PRINT *
+         GO TO 400
+      ENDIF
 
       ALLOCATE(TAB_8(MXTS,MXTB),STAT=I);IF(I.NE.0) GOTO 901
       ALLOCATE(RAB_8(MXTS,MXTB),STAT=I);IF(I.NE.0) GOTO 901
@@ -502,6 +511,8 @@ C  -------------------------------------------------------------------
 
          ENDIF ! (FILI(I)(1:4).NE.'NONE')
       ENDDO ! I=1,1
+
+ 400  CONTINUE
  
 C  GENERATE REPORT
 C  ---------------


### PR DESCRIPTION
Please review changes to dupcman.f and duptac.f to test for 0 reports in input file. This change needs to be integrated into release/bufr-dump.v1.0.0 for WCOSS2.

This relates to redmine task 102666, to fix the operational failure of rap_dump on 20220318 on WCOSS1 Cray.