### PR TITLE
Add Jet support to bufr-dump build

### DIFF
--- a/modulefiles/bufrdump_jet.lua
+++ b/modulefiles/bufrdump_jet.lua
@@ -1,0 +1,15 @@
+help([[
+Load environment to build bufr-dump on Hera
+]])
+
+load("cmake/3.20.1")
+
+prepend_path("MODULEPATH", "/lfs4/HFIP/hfv3gfs/role.epic/hpc-stack/libs/intel-18.0.5.274/modulefiles/stack")
+load("hpc/1.2.0")
+load("hpc-intel/18.0.5.274")
+load("hpc-impi/2018.4.274")
+
+-- Load common modules for this package
+load("bufrdump_common")
+
+whatis("Description: bufr-dump build environment")

--- a/ush/build.sh
+++ b/ush/build.sh
@@ -10,9 +10,10 @@ INSTALL_PREFIX=${INSTALL_PREFIX:-"$pkg_root/install"}
 MODULEFILE_INSTALL_PREFIX=${MODULEFILE_INSTALL_PREFIX:-"modulefiles"}
 
 target=$(echo $INSTALL_TARGET | tr [:upper:] [:lower:])
-if [[ "$target" =~ ^(wcoss2|hera|orion)$ ]]; then
+if [[ "$target" =~ ^(wcoss2|hera|orion|jet)$ ]]; then
   source $pkg_root/versions/build.ver
   set +x
+  export LMOD_SYSTEM_DEFAULT_MODULES=${LMOD_SYSTEM_DEFAULT_MODULES:-contrib}
   module reset
   module use $pkg_root/modulefiles
   module load bufrdump_$target


### PR DESCRIPTION
This PR adds build support for RDHPCS Jet in bufr-dump.

Changes:

- Create Jet lua modulefile.
- Add "jet" to target list in `ush/build.sh`.
- In `build.sh`, add check for `LMOD_SYSTEM_DEFAULT_MODULES` value and set to `contrib` if null. WCOSS2 sets `LMOD_SYSTEM_DEFAULT_MODULES=envvar/1.0` but this variable is not set on the RDHPCS platforms so `module reset` doesn't work. Have to set this variable on the R&Ds to use `module reset` on those platforms. Tested this on WCOSS2 to make sure it didn't impact `LMOD_SYSTEM_DEFAULT_MODULES` and `module reset`.

Resolves #16